### PR TITLE
fix: skip deleted markdown files instead of failing the sync

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -120,7 +120,9 @@ function getHeaders(notionToken) {
     };
 }
 function getEditedMarkdownFiles() {
-    const allChangedFiles = cp.execSync('git show --name-only --pretty=format:', {
+    // Exclude deleted paths: they are not in the working tree and have no
+    // content left to sync.
+    const allChangedFiles = cp.execSync('git show --name-only --diff-filter=d --pretty=format:', {
         encoding: 'utf-8',
     });
     const changedMarkdownFiles = allChangedFiles
@@ -225,6 +227,10 @@ async function pushMdFilesToNotion(notionToken, dryRun) {
     }
     // loop over all the markdown files and push the corresponding ones to notion
     for (let f of markdownFiles) {
+        if (!fs_1.default.existsSync(f)) {
+            core.info(`Skipping ${f}: not present in the working tree`);
+            continue;
+        }
         const content = fs_1.default.readFileSync(f, 'utf8');
         const parsed_content = (0, gray_matter_1.default)(content);
         if (typeof parsed_content.data.notion_page === 'string' &&

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,9 +61,14 @@ function getHeaders(notionToken: string) {
 }
 
 function getEditedMarkdownFiles(): string[] {
-  const allChangedFiles = cp.execSync('git show --name-only --pretty=format:', {
-    encoding: 'utf-8',
-  });
+  // Exclude deleted paths: they are not in the working tree and have no
+  // content left to sync.
+  const allChangedFiles = cp.execSync(
+    'git show --name-only --diff-filter=d --pretty=format:',
+    {
+      encoding: 'utf-8',
+    }
+  );
 
   const changedMarkdownFiles = allChangedFiles
     .trim()
@@ -197,6 +202,11 @@ async function pushMdFilesToNotion(notionToken: string, dryRun: boolean) {
 
   // loop over all the markdown files and push the corresponding ones to notion
   for (let f of markdownFiles) {
+    if (!fs.existsSync(f)) {
+      core.info(`Skipping ${f}: not present in the working tree`);
+      continue;
+    }
+
     const content = fs.readFileSync(f, 'utf8');
     const parsed_content = matter(content);
     if (


### PR DESCRIPTION
## Problem

Any commit that deletes a markdown file fails the action:

```
❌ Unexpected error: Error: ENOENT: no such file or directory, open 'docs/some-page.md'
Markdown-to-Notion sync failed.
```

`getEditedMarkdownFiles()` uses `git show --name-only`, which lists deleted paths alongside added and modified ones. Each path is then read straight from the working tree (`fs.readFileSync(f, 'utf8')`) with no existence check, so a deleted path throws.

Because the read happens inside the loop and the throw propagates to `run()`, it does not merely produce a red build — it aborts the whole run. Any markdown file positioned after the deleted one is never synced, so a Notion page can silently go stale. We hit this across a fleet of ~130 repos syncing with this action; most have no `notion_page` frontmatter at all, so the only visible effect is a failing job on the default branch.

## Fix

Two small changes, in `getEditedMarkdownFiles()` and the sync loop:

1. `--diff-filter=d` on the `git show` invocation, so deleted paths are never listed. A deleted file has no content left to sync.
2. An `fs.existsSync(f)` guard before the read, which skips with a log line rather than throwing. Defence in depth for any other way a listed path can be absent from the working tree.

Deliberately kept narrow: no `try`/`catch` around the loop body, so genuine Notion API failures still fail the run as they do today.

## Verification

Scratch repository, one commit that deletes `.github/deleted-doc.md` and edits `kept-doc.md`:

```
$ git show --name-only --pretty=format: | grep '\.md$'                    # before
.github/deleted-doc.md
kept-doc.md

$ git show --name-only --diff-filter=d --pretty=format: | grep '\.md$'    # after
kept-doc.md
```

Running the bundles against that repository:

```
v1.2.0   ::error::❌ Unexpected error: Error: ENOENT ... open '.github/deleted-doc.md'
         ::error::Markdown-to-Notion sync failed.
         exit=1          # note: kept-doc.md was never reached

patched  no notion frontmatter found for kept-doc.md
         ✅ Pushed all markdown files to notion
         exit=0
```

The `existsSync` guard was exercised separately by deleting a modified file from the working tree after committing it, so the path is still in `HEAD`'s diff:

```
patched  Skipping kept-doc.md: not present in the working tree
         ✅ Pushed all markdown files to notion
         exit=0
```

`dist/index.js` was rebuilt with `npm ci && npm run build`; the bundle diff is 7 added and 1 removed lines, confined to this change. `npx prettier --check src/main.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
