### PR TITLE
fix: skip deleted markdown files instead of crashing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -120,13 +120,13 @@ function getHeaders(notionToken) {
     };
 }
 function getEditedMarkdownFiles() {
-    const allChangedFiles = cp.execSync('git show --name-only --pretty=format:', {
-        encoding: 'utf-8',
-    });
+    // --diff-filter=d excludes deleted files: they can't be read from the
+    // working tree and there is nothing to push for them.
+    const allChangedFiles = cp.execSync('git show --name-only --diff-filter=d --pretty=format:', { encoding: 'utf-8' });
     const changedMarkdownFiles = allChangedFiles
         .trim()
         .split('\n')
-        .filter((fn) => fn.endsWith('.md'));
+        .filter((fn) => fn.endsWith('.md') && fs_1.default.existsSync(fn));
     return changedMarkdownFiles;
 }
 async function getAllChildrenBlocks(blockId, token) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,14 +61,17 @@ function getHeaders(notionToken: string) {
 }
 
 function getEditedMarkdownFiles(): string[] {
-  const allChangedFiles = cp.execSync('git show --name-only --pretty=format:', {
-    encoding: 'utf-8',
-  });
+  // --diff-filter=d excludes deleted files: they can't be read from the
+  // working tree and there is nothing to push for them.
+  const allChangedFiles = cp.execSync(
+    'git show --name-only --diff-filter=d --pretty=format:',
+    { encoding: 'utf-8' }
+  );
 
   const changedMarkdownFiles = allChangedFiles
     .trim()
     .split('\n')
-    .filter((fn) => fn.endsWith('.md'));
+    .filter((fn) => fn.endsWith('.md') && fs.existsSync(fn));
 
   return changedMarkdownFiles;
 }


### PR DESCRIPTION
## Problem

When the commit being processed **deletes** a `.md` file, the action crashes:

```
❌ Unexpected error: Error: ENOENT: no such file or directory, open 'docs/old-page.md'
    at Object.readFileSync (node:fs:441:20)
    at pushMdFilesToNotion (.../dist/index.js:228:38)
```

`getEditedMarkdownFiles()` collects changed paths with `git show --name-only`, which includes files removed by the commit. `pushMdFilesToNotion()` then calls `fs.readFileSync` on every path before checking for `notion_page` frontmatter, so a deleted file fails the whole run.

This bites hardest in a shared workflow that runs on every PR / push across many repos: any PR that removes a markdown file — a stale README, an old ADR, a doc that never had Notion frontmatter in the first place — turns the check red, even though there is nothing to sync.

### Reproduce

```sh
git init t && cd t
git commit --allow-empty -m init
echo hi > doc.md && git add . && git commit -m add
git rm doc.md && git commit -m del
# run the action against HEAD → ENOENT: no such file or directory, open 'doc.md'
```

## Fix

- `git show --name-only --diff-filter=d` — exclude deletions at the source.
- `fs.existsSync(fn)` in the filter as a belt-and-braces guard (also covers renames/`git show` edge cases where a listed path is not in the working tree).

Deleted pages are left untouched in Notion, which matches the action's existing behaviour of only ever pushing content for files it can read.

`dist/index.js` rebuilt with `npm run build`; the diff is limited to the changed function.

## Verified

Ran the previous and rebuilt `dist/index.js` against the repro above in dry-run mode:

- before: `ENOENT … open 'doc.md'`, exit 1
- after: `No markdown files with changes detected for current commit`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)